### PR TITLE
FDL-712 - workaround for stripped off amp-ad attribute (rtc-config)

### DIFF
--- a/etc/docker/nginx/default.conf
+++ b/etc/docker/nginx/default.conf
@@ -53,6 +53,8 @@ server {
     location ~ ^/index\.php(/|$) {
 
         # workaround for tags in amp (amp-converter strips them off)
+        sub_filter '<!--amp-ad'  '<amp-ad';
+        sub_filter '</amp-ad-->'  '</amp-ad>';
         sub_filter '<!--amp-consent'  '<amp-consent';
         sub_filter '</amp-consent-->'  '</amp-consent>';
         sub_filter '<!--amp-fx-flying-carpet'  '<aamp-fx-flying-carpet';


### PR DESCRIPTION
https://sjira.funkemedien.de/projects/FDL/issues/FDL-712