### PR TITLE
Fdl 677

### DIFF
--- a/.env
+++ b/.env
@@ -122,3 +122,6 @@ MAILER_DSN=smtp://localhost
 ###< symfony/mailer ###
 
 FROM_EMAIL=contact@publisher.test
+
+# after how many charachters in the body's paragraph the ad should to be placed
+ADS_CHARACTERS=200

--- a/src/SWP/Bundle/CoreBundle/Resources/config/twig.yml
+++ b/src/SWP/Bundle/CoreBundle/Resources/config/twig.yml
@@ -65,5 +65,6 @@ services:
         arguments:
             - '@swp_content_bundle.manager.media'
             - '@SWP\Bundle\ContentBundle\File\FileExtensionChecker'
+            - '%env(int:ADS_CHARACTERS)%'
         tags:
             - { name: twig.extension }

--- a/src/SWP/Bundle/CoreBundle/Twig/ArticleBodyExtension.php
+++ b/src/SWP/Bundle/CoreBundle/Twig/ArticleBodyExtension.php
@@ -36,10 +36,16 @@ final class ArticleBodyExtension extends AbstractExtension
      */
     private $fileExtensionChecker;
 
-    public function __construct(MediaManagerInterface $mediaManager, FileExtensionCheckerInterface $fileExtensionChecker)
+    /**
+     * @var int
+     */
+    private $paragraphChars;
+
+    public function __construct(MediaManagerInterface $mediaManager, FileExtensionCheckerInterface $fileExtensionChecker, $paragraphChars)
     {
         $this->mediaManager = $mediaManager;
         $this->fileExtensionChecker = $fileExtensionChecker;
+        $this->paragraphChars = $paragraphChars;
     }
 
     /**
@@ -49,7 +55,68 @@ final class ArticleBodyExtension extends AbstractExtension
     {
         return [
             new TwigFunction('setRendition', [$this, 'setRendition']),
+            new TwigFunction('setInlineAds', [$this, 'setInlineAds']),
         ];
+    }
+
+    public function setInlineAds(string $body): array
+    {
+        # split the body into paragraphs
+        $paragraphs = explode("</p>", $body);
+
+        $tmp = [];
+        $splittedBody = [];
+        $parLength = 0;
+        $paragraphChars = $this->paragraphChars;
+        foreach ($paragraphs as $key => $paragraph) {
+            $paragraph .= '</p>';
+            $safeToAdd = true;
+
+            #check if the next element is a non empty paragraph
+            if (isset($paragraphs[$key+1]) && strlen($paragraphs[$key+1]) && $key < sizeof($paragraphs)) {
+                $bodyDOM2 =  new \DOMDocument();
+                @$bodyDOM2->loadHTML((mb_convert_encoding($paragraphs[$key+1], 'HTML-ENTITIES', 'UTF-8')));
+                $pars2 = $bodyDOM2->getElementsByTagName('*')->item(2);
+                if ($pars2->tagName != 'p' || ($pars2->tagName == 'p' && strlen($pars2->textContent) == 0)) {
+                    $safeToAdd = false;
+                }
+            }
+
+            if (strlen($paragraph) > 0) {
+                $bodyDOM =  new \DOMDocument();
+                @$bodyDOM->loadHTML((mb_convert_encoding($paragraph, 'HTML-ENTITIES', 'UTF-8')));
+                $pars = $bodyDOM->getElementsByTagName('p');
+
+                # loop through all the p tags inside the array
+                foreach ($pars as $node) {
+                    $parLength += strlen($node->textContent);
+
+                    if ($parLength >= $paragraphChars && $safeToAdd) {
+                        $tmp[] = $paragraph;
+                             
+                        $parHolder = '';
+                        foreach ($tmp as $tmpParagraph) {
+                            $parHolder .= $tmpParagraph;
+                        }
+                        $splittedBody[] = $parHolder;
+                        $tmp = [];
+                        $parLength = 0;
+                    } else {
+                        $tmp[] = $paragraph;
+                    }
+                }
+            }
+        }
+  
+        if (!empty($tmp)) {
+            $parHolder = '';
+            foreach ($tmp as $tmpParagraph) {
+                $parHolder .= $tmpParagraph;
+            }
+            $splittedBody[] = $parHolder;
+        }
+
+        return $splittedBody;
     }
 
     public function setRendition(Meta $articleMeta, string $renditionName): void


### PR DESCRIPTION
Fixes #
(comma separated list of tickets/issues/bugs fixed by the PR)

## Proposed Changes

For the ad integration on articles we need a dynamic functionality. The ad integration should be depending on paragraphs and the numbers of characters.

The following rules should be respected:

- an adslots should be integrated after every paragraph (with 200 characters)
- an paragraph should have at least 200 characters
- an adslot should only be integrated if another paragraph follows
- no integration before and after one single paragraph
- a item of a list could be a paragraph if it has more than 200 characters
- no integration before a list
- no integration after headlines
- the number of characters should be adjustable in den backend
- has a paragraph less than 200 characters the next paragraph(s) should be added till the numbers of 200 characters is reached

License: AGPLv3
